### PR TITLE
feat: support attachments and reactions in conversations

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,5 +1,7 @@
 # backend/app/__init__.py
 
+import os
+
 from flask import Flask
 from .config import load_config
 from .extensions import db, migrate, bcrypt, jwt, limiter, socketio
@@ -17,6 +19,8 @@ def create_app() -> Flask:
     load_config(app)
 
     configure_json_logging(app)
+
+    os.makedirs(app.config.get("UPLOAD_FOLDER", "uploads"), exist_ok=True)
 
     db.init_app(app)
     migrate.init_app(app, db)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass, asdict
 import os
 
 
+_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+_DEFAULT_UPLOAD_DIR = os.path.join(_BASE_DIR, "static", "uploads")
+
+
 def _get_env(name: str, default: str | None = None) -> str:
     val = os.getenv(name, default)
     if val is None:
@@ -28,6 +32,9 @@ class Config:
     
     # Frontend
     FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:5173")
+
+    # Fichiers
+    UPLOAD_FOLDER: str = os.getenv("UPLOAD_FOLDER", _DEFAULT_UPLOAD_DIR)
 
 
 def load_config(app) -> None:

--- a/backend/app/schemas_message.py
+++ b/backend/app/schemas_message.py
@@ -1,6 +1,49 @@
 # backend/app/schemas_message.py
 
+from __future__ import annotations
+
+from typing import Any
+
+from flask import url_for
 from marshmallow import Schema, fields
+
+
+def _original_name(path: str) -> str:
+    if not path:
+        return ""
+    _, _, original = path.partition("_")
+    return original or path
+
+
+class FileSchema(Schema):
+    id_file = fields.Int(dump_only=True)
+    mime = fields.Str()
+    taille = fields.Int()
+    sha256 = fields.Str()
+    filename = fields.Method("get_filename")
+    url = fields.Method("get_url")
+
+    def get_filename(self, obj: Any) -> str:
+        return _original_name(getattr(obj, "path", ""))
+
+    def get_url(self, obj: Any) -> str:
+        try:
+            return url_for("messages.download_file", file_id=getattr(obj, "id_file", 0))
+        except RuntimeError:
+            return f"/api/messages/files/{getattr(obj, 'id_file', 0)}"
+
+
+class ReactionSchema(Schema):
+    emoji = fields.Str(required=True)
+    id_user = fields.Int(required=True)
+    ts = fields.DateTime(dump_only=True)
+    is_mine = fields.Method("get_is_mine")
+
+    def get_is_mine(self, obj: Any) -> bool:
+        context = self.context if isinstance(self.context, dict) else {}
+        current_user = context.get("user_id")
+        return bool(current_user and getattr(obj, "id_user", None) == current_user)
+
 
 class MessageSchema(Schema):
     id_msg = fields.Int(dump_only=True)
@@ -8,3 +51,20 @@ class MessageSchema(Schema):
     ts_msg = fields.DateTime(dump_only=True)
     sender_id = fields.Int(dump_only=True)
     conv_id = fields.Int(dump_only=True)
+    files = fields.Nested(FileSchema, many=True, dump_only=True)
+    reactions = fields.Nested(ReactionSchema, many=True, dump_only=True)
+    reaction_summary = fields.Method("get_reaction_summary")
+
+    def get_reaction_summary(self, obj: Any) -> list[dict[str, Any]]:
+        summary: dict[str, dict[str, Any]] = {}
+        context = self.context if isinstance(self.context, dict) else {}
+        current_user = context.get("user_id")
+        for reaction in getattr(obj, "reactions", []) or []:
+            info = summary.setdefault(
+                getattr(reaction, "emoji", ""),
+                {"emoji": getattr(reaction, "emoji", ""), "count": 0, "mine": False},
+            )
+            info["count"] += 1
+            if current_user and getattr(reaction, "id_user", None) == current_user:
+                info["mine"] = True
+        return list(summary.values())


### PR DESCRIPTION
## Summary
- add backend upload configuration and extend message serialization for files and reactions
- expose file download and reaction toggle endpoints while storing uploaded attachments on disk
- enhance the messaging UI with emoji insertion, attachment previews, downloads, and reaction controls

## Testing
- python -m compileall backend/app/__init__.py backend/app/config.py backend/app/routes/message.py backend/app/schemas_message.py
- npm --prefix frontend/secure_messagerie run build

------
https://chatgpt.com/codex/tasks/task_e_68ce72379ef0832aa687a7bcdbd46918